### PR TITLE
fix svc wardle/api

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,12 +114,33 @@ kubectl apply -f artifacts/example/service.yaml
 
 #### 测试
 
-以下几步都不通
-
-- 创建 APIService
+- 注册 APIService
 
 ```shell
 kubectl apply -f artifacts/example/apiservice.yaml
+```
+
+- 为aa-server注册服务
+```shell
+kubectl create namespace wardle
+
+# 创建无选择器的服务
+kubectl -n wardle apply -f artifacts/example/service.yaml
+
+# 手工将其endpoint执行运行在集群外的aa-server
+kubectl -n wardle apply -f - <<EOF
+kind: Endpoints
+apiVersion: v1
+metadata:
+  name: api
+subsets:
+  - addresses:
+      - ip: # 这里填写本机地址
+    ports:
+      - port: 8443
+        name: https
+EOF
+
 ```
 
 - 创建 flunders 资源

--- a/artifacts/example/endpoints.yaml
+++ b/artifacts/example/endpoints.yaml
@@ -1,0 +1,10 @@
+kind: Endpoints
+apiVersion: v1
+metadata:
+  name: api
+subsets:
+  - addresses:
+      - ip: # 这里填写本机地址
+    ports:
+      - port: 8443
+        name: https

--- a/artifacts/example/service.yaml
+++ b/artifacts/example/service.yaml
@@ -8,5 +8,4 @@ spec:
   - port: 443
     protocol: TCP
     targetPort: 443
-  selector:
-    apiserver: "true"
+    name: https


### PR DESCRIPTION
无法访问的原因是代表aa-server的服务wardle/api没有endpoints

```
kubectl get apiservice
...
v1alpha1.wardle.example.com            wardle/api   False (MissingEndpoints)   18m
```

如果aa-server运行在集群外部，可以手工指定endpoints；或者将aa-server打包镜像运行在集群中